### PR TITLE
Correct wrong path for Mixer Sample Load

### DIFF
--- a/lib/mixer.py
+++ b/lib/mixer.py
@@ -46,10 +46,15 @@ def combine(group, sync_offsets, mute_tracks,
                                   basefile + "-canon.mp3")
         clean_name = os.path.join(group.path, "cache",
                                   basefile + "-clean.mp3")
+        canon_name_f = os.path.join("cache",
+                                  basefile + "-canon.mp3")
+        clean_name_f = os.path.join("cache",
+                                  basefile + "-clean.mp3")
+        log(clean_name)
         if os.path.exists(clean_name):
-            sample = group.load(clean_name)
+            sample = group.load(clean_name_f)
         elif os.path.exists(canon_name):
-            sample = group.load(canon_name)
+            sample = group.load(canon_name_f)
         else:
             log("cannot find canonical audio or cleaned audio, die!")
             quit()


### PR DESCRIPTION
A small workaround so that the correct path is passed to be able to load the samples.
It may not be the most elegant solution, but at least it works for me

The problem that this is supposed to solve is the following:

My project files are located in the following directory: "F:\OneDrive\Dokumente\#SIMON\GIT\virtual_choir\project"
I use the shell to change to the directory in which the project folder and sync-tracks.py are located.
I then start the synchronisation via "python sync-tracks.py --no-video project"
Everything works fine then, but an error is generated when the mixer tries to load the samples at the end.
Without my fix, it tries to load the samples via the following path "project\project\cache\MYSAMPLE-clean.mp3".
With the fix it uses the correct path "project\cache\MYSAMPLE-clean.mp3".

I hope this explanation helps a little to clarify the problem
Best regards