### PR TITLE
Add ubuntu install instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 *~
+*/__pycache__/
+
+# Build results
+results/
+cache/
+*/audacity_import.lof
+*/full-mix.mp3

--- a/README.md
+++ b/README.md
@@ -140,6 +140,25 @@ When I do this sort of thing, I run the script, see what package
 import fails, install it, repeat ..., eventually I have all the
 dependencies and the script works, yeah!
 
+## Ubuntu Instructions using Conda
+
+The following has been tested on Ubuntu 20.04.
+
+1. Open terminal and open system packages:
+```bash
+sudo apt install sox libsox-fmt-all ffmpeg gcc g++ make
+```
+2. Install [Anaconda](https://www.anaconda.com/products/individual) or conda package manager
+3. Open a terminal, create environment `vchoir`, and activate it.
+```bash
+conda env create --file environment.yml
+conda activate vchoir
+```
+4. Run test using demo clips
+```bash
+python sync-tracks.py demo_clips/ --crop none
+```
+
 # Questions:
 
 I'm sure you have many.  Please feel free to ask for help!  As I write
@@ -160,4 +179,3 @@ all worth while!
 ## Sample recording instructions:
 
    https://docs.google.com/document/d/1mWFmZ76PZErq-XEIeCNmw1FZdtWXVHjOARTSdNITCzA/edit?usp=sharing
-

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,17 @@
+name: vchoir
+channels:
+  - defaults
+dependencies:
+  - python=3.8.5
+  - libgcc-ng
+  - lxml
+  - tqdm
+  - matplotlib
+  - cmake
+  - pip
+  - pip:
+    - librosa
+    - pydub
+    - opencv-python
+    - sk_video
+    - dlib


### PR DESCRIPTION
Hi Curt,

Awesome library here.  Thought to add the installation instructions while still semi-fresh based on a Ubuntu installation.  Testing the instructions on one more system may be useful.  I wasn't sure if/how you wanted contributions so of course feel free to edit/revise the instructions to fit.

By the way, is there a better way to test your installation using the demo clips?  Without the `--crop none` option it would not proceed.  I also seem to get `full-mix.mp3` without audio on occasion.  If I can pin that down I'll create an issue.

Thanks again for sharing this!